### PR TITLE
33 typeerror on cli invocation post typer integration missing required positional arguments

### DIFF
--- a/pan_os_upgrade/upgrade.py
+++ b/pan_os_upgrade/upgrade.py
@@ -76,6 +76,12 @@ from pan_os_upgrade.models import SnapshotReport, ReadinessCheckReport
 
 
 # ----------------------------------------------------------------------------
+# Define Typer command-line interface
+# ----------------------------------------------------------------------------
+app = typer.Typer(help="PAN-OS Upgrade script")
+
+
+# ----------------------------------------------------------------------------
 # Define logging levels
 # ----------------------------------------------------------------------------
 LOGGING_LEVELS = {
@@ -1504,6 +1510,7 @@ def perform_reboot(firewall: Firewall, ha_details: Optional[dict] = None) -> Non
 # ----------------------------------------------------------------------------
 # Primary execution of the script
 # ----------------------------------------------------------------------------
+@app.command()
 def main(
     ip_address: Annotated[
         str,
@@ -1721,4 +1728,4 @@ def main(
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 license = "Apache 2.0"
@@ -23,7 +23,7 @@ mkdocs-material = "^9.5.4"
 mkdocstrings = "^0.24.0"
 
 [tool.poetry.scripts]
-pan-os-upgrade = 'pan_os_upgrade.upgrade:main'
+pan-os-upgrade = 'pan_os_upgrade.upgrade:app'
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Pull Request Summary

This pull request addresses the TypeError issue encountered when running the pan-os-upgrade script from the CLI. The error was caused by an outdated script entry in pyproject.toml, which did not align with the recent integration of Typer for command-line argument parsing.

## Modifications

- Updated the [tool.poetry.scripts] section in pyproject.toml.
- The script entry now points to the Typer app instance, enabling correct CLI argument handling.

## Detailed Changes

Changed the script entry in pyproject.toml from:

```toml
[tool.poetry.scripts]
pan-os-upgrade = 'pan_os_upgrade.upgrade:main'
```

to:

```toml
[tool.poetry.scripts]
pan-os-upgrade = 'pan_os_upgrade.upgrade:app'
```

ensuring the CLI commands are handled by Typer's app instance.

## Benefits

Resolves the TypeError during CLI invocation.
Ensures compatibility with Typer for effective command-line argument parsing.

## Testing

Conducted thorough testing to confirm that the script now accepts and processes CLI arguments as expected.
Validated that the script functions correctly for all supported commands and options.

## Additional Notes

The changes have been tested on 3.11.
No additional dependencies were added or modified.

## Linked Issue:

This pull request fixes the issue described in #33 

