### PR TITLE
Update Docker build command to include path

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Build the container image
         run: |
-          docker build --tag ghcr.io/cdot65/pan-os-upgrade:latest
+          docker build --tag ghcr.io/cdot65/pan-os-upgrade:latest docker
           docker push ghcr.io/cdot65/pan-os-upgrade:latest


### PR DESCRIPTION
This pull request updates the Docker build command to include the path for building the container image. The previous command was missing the path, causing the build to fail. This fix ensures that the Docker build command includes the correct path and allows the container image to be built successfully.