### PR TITLE
70 Enhance HA Support for Panorama Instances

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 ADD settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.1.1
-RUN pip install --no-cache-dir pan-os-upgrade==1.1.1
+# Note: The requirements.txt should contain pan-os-upgrade==1.1.2
+RUN pip install --no-cache-dir pan-os-upgrade==1.1.2
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,10 +2,19 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
+## Version 1.1.2
+
+**Release Date:** *<20240208>*
+
+### What's New
+
+- Fixed a bug that prevented HA Panorama appliances from being targeted for upgrades
+
 ## Version 1.1.1
 
 **Release Date:** *<20240204>*
 
+<!-- trunk-ignore(markdownlint/MD024) -->
 ### What's New
 
 - Fixed a bug that prevented access to the `logo.png` file used by the PDF generation process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"


### PR DESCRIPTION
This PR introduces improvements to the `pan-os-upgrade` CLI tool by distinguishing High Availability (HA) functionality between PAN-OS firewalls and Panorama appliances. The motivation stems from the unique HA response structure of Panorama, which lacks the "group" concept present in firewall responses, leading to incompatibilities with the existing `handle_ha_logic` function.

**Key Changes:**

- **Dedicated HA Handling for Panorama:** We've introduced separate logic to handle HA functionality for Panorama instances, taking into account the distinct HA response structure. This ensures that the upgrade process for HA Panorama setups is accurately managed, aligning with Panorama's HA architecture.

- **Split HA Sync Checks:** The HA synchronization checks have been bifurcated between PAN-OS and Panorama appliances to cater to their respective response structures and upgrade requirements. This allows for more precise control and validation during the upgrade process, particularly for HA setups.

- **Version Update:** The `pan-os-upgrade` tool has been updated to version 1.1.2 to encapsulate these enhancements and ensure users benefit from the latest improvements.

**Motivation:**

The need for these changes was highlighted by the challenges encountered when upgrading HA Panorama instances using the existing tool. The absence of "group" structures in Panorama's HA state responses necessitated a tailored approach to efficiently manage the upgrade process in complex Panorama environments.

**Impact:**

By addressing this gap, the PR significantly enhances the `pan-os-upgrade` tool's utility and reliability, particularly for customers managing large numbers of HA Panorama instances. It facilitates a seamless and safe upgrade experience, reinforcing the tool's value in maintaining robust and up-to-date Panorama configurations.

**Testing:**

The modifications have been thoroughly tested in environments simulating HA Panorama setups, ensuring that the new logic effectively handles the unique HA state responses of Panorama and seamlessly integrates with the overall upgrade process.

This enhancement marks a critical step towards making the `pan-os-upgrade` tool more versatile and accommodating to a wider range of PAN-OS and Panorama configurations, particularly those involving complex HA setups.

Resolves: [Link to the GitHub issue]
