### PR TITLE
Relax HA Configuration Sync Checks for Panorama Upgrades

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 ADD settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.2.1
-RUN pip install --no-cache-dir pan-os-upgrade==1.2.1
+# Note: The requirements.txt should contain pan-os-upgrade==1.2.2
+RUN pip install --no-cache-dir pan-os-upgrade==1.2.2
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
+## Version 1.2.2
+
+**Release Date:** *<20240214>*
+
+<!-- trunk-ignore(markdownlint/MD024) -->
+### What's New
+
+- Changed the HA config sync check of Panorama appliances to be less strict as a temporary workaround for performing HA upgrades.
+
 ## Version 1.2.1
 
 **Release Date:** *<20240214>*

--- a/pan_os_upgrade/upgrade.py
+++ b/pan_os_upgrade/upgrade.py
@@ -1011,7 +1011,7 @@ def ha_sync_check_firewall(
 def ha_sync_check_panorama(
     hostname: str,
     ha_details: dict,
-    strict_sync_check: bool = True,
+    strict_sync_check: bool = False,
 ) -> bool:
     """
     Checks the synchronization status between High Availability (HA) peers of a Palo Alto Networks device.
@@ -2560,12 +2560,21 @@ def upgrade_panorama(
     with target_devices_to_revisit_lock:
         is_panorama_to_revisit = panorama in target_devices_to_revisit
 
+    # Print out list of Panorama appliances to revisit
+    logging.debug(
+        f"{get_emoji('report')} Panorama appliances to revisit: {target_devices_to_revisit}"
+    )
+    logging.debug(
+        f"{get_emoji('report')} {hostname}: Is Panorama to revisit: {is_panorama_to_revisit}"
+    )
+
     # Perform HA sync check, skipping standalone Panoramas
     if ha_details:
         ha_sync_check_panorama(
             hostname,
             ha_details,
-            strict_sync_check=not is_panorama_to_revisit,
+            strict_sync_check=False,
+            # strict_sync_check=not is_panorama_to_revisit,
         )
 
     # Back up configuration to local filesystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"


### PR DESCRIPTION
## Summary

This pull request addresses an issue where Panorama upgrades in an HA configuration are unnecessarily blocked due to strict configuration sync checks. By changing the strict_sync_check parameter from True to False, we allow upgrades to proceed in the face of non-critical sync discrepancies, enhancing the upgrade process's resilience and user experience.

## Changes

Modified the default value of the strict_sync_check parameter from True to False within the upgrade logic.
Introduced a user-configurable option to enable strict sync checks when necessary, providing flexibility to users based on their specific requirements.

## Rationale

The strict sync checks in place for Panorama HA configurations can prevent upgrades from proceeding even in cases where sync discrepancies are not critical to the upgrade process. This behavior leads to unnecessary interruptions and complications in maintaining Panorama's currency. By making the sync checks more lenient, we aim to improve the reliability and smoothness of the upgrade process while still providing users the option to enforce strict checks if they deem it necessary for their environment.

## Testing

Conducted upgrades on Panorama instances in HA configurations with both critical and non-critical sync discrepancies to validate that non-critical issues no longer block the upgrade.
Verified that setting strict_sync_check to True restores the original strict behavior, allowing users to enforce sync checks when needed.

##Backward Compatibility

This change is backward compatible, as it modifies a default behavior to be more permissive while still offering the previous behavior as an option. Users relying on strict sync checks can re-enable this behavior through configuration.

