### PR TITLE
87 inconsistent ha peer upgrade order due to thread limitations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 ADD settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.2.3
-RUN pip install --no-cache-dir pan-os-upgrade==1.2.3
+# Note: The requirements.txt should contain pan-os-upgrade==1.2.4
+RUN pip install --no-cache-dir pan-os-upgrade==1.2.4
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
+## Version 1.2.4
+
+**Release Date:** *<20240215>*
+
+<!-- trunk-ignore(markdownlint/MD024) -->
+### What's New
+
+- Remove HA sync strict check before upgrade process to account for scenarios where a passive firewall is upgrades within a thread of the first phase before the active is targeted within the same phase.
+
 ## Version 1.2.3
 
 **Release Date:** *<20240214>*

--- a/pan_os_upgrade/upgrade.py
+++ b/pan_os_upgrade/upgrade.py
@@ -938,7 +938,7 @@ def handle_panorama_ha(
 def ha_sync_check_firewall(
     hostname: str,
     ha_details: dict,
-    strict_sync_check: bool = True,
+    strict_sync_check: bool = False,
 ) -> bool:
     """
     Checks the synchronization status between High Availability (HA) peers of a Palo Alto Networks device.
@@ -2294,16 +2294,11 @@ def upgrade_firewall(
         f'assurance/readiness_checks/{hostname}/pre/{time.strftime("%Y-%m-%d_%H-%M-%S")}.json',
     )
 
-    # Determine strictness of HA sync check
-    with target_devices_to_revisit_lock:
-        is_device_to_revisit = firewall in target_devices_to_revisit
-
     # Perform HA sync check, skipping standalone firewalls
     if ha_details:
         ha_sync_check_firewall(
             hostname,
             ha_details,
-            strict_sync_check=not is_device_to_revisit,
         )
 
     # Back up configuration to local filesystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.2.3"
+version = "1.2.4"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"


### PR DESCRIPTION
## Summary

This PR introduces modifications to the firewall upgrade process, specifically targeting the handling of High Availability (HA) synchronization checks. Previously, strict HA synchronization checks could potentially halt the upgrade process if HA peers were not perfectly synchronized, especially in scenarios where the number of targeted firewalls exceeded the available thread count. This change aims to enhance the flexibility and resilience of the upgrade process by relaxing the HA synchronization requirements.

## Changes Made

HA Synchronization Check Adjustment: The default behavior of the ha_sync_check_firewall function has been updated to not enforce strict HA synchronization (strict_sync_check: bool = False). This adjustment allows the upgrade process to proceed even in cases where HA synchronization might not be perfect, accommodating the asynchronous nature of multi-threaded operations.

**Simplified HA Sync Check Execution**: The execution of the ha_sync_check_firewall function within the upgrade_firewall function has been simplified by removing the conditional strict_sync_check argument. The function now operates under the assumption that strict sync checks are not required by default, thus streamlining the logic and reducing complexity.

**Removed Redundant Code**: Code segments that determined the necessity of strict HA sync checks based on the revisit status of devices (is_device_to_revisit) have been removed. This elimination reflects the shift towards a more lenient approach to HA sync checks, rendering such checks unnecessary.

## Implications

- **Operational Flexibility**: By allowing upgrades to proceed without strict HA sync, the upgrade process becomes more adaptable to the dynamic conditions of HA environments, reducing the likelihood of upgrade interruptions.
- **Risk Consideration**: While this change improves operational flexibility, it also introduces a need for careful monitoring of HA status post-upgrade. Administrators should be vigilant in identifying and resolving any HA synchronization discrepancies that may arise due to relaxed checks.

## Testing

Extensive testing in both standalone and HA-configured environments is recommended to ensure that the relaxed synchronization checks do not introduce unexpected behaviors or instability.

Monitoring tools and procedures should be in place to quickly identify and address any HA sync issues following upgrades.

## Conclusion

This PR represents a strategic shift towards a more resilient and adaptable upgrade process for Palo Alto Networks firewalls. 

By accommodating the complexities of HA environments and the limitations of multi-threaded operations, it aims to provide a smoother and more reliable upgrade experience.




