### PR TITLE
106 firewall snapshot after upgrade not generated

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 ADD settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.3.3
-RUN pip install --no-cache-dir pan-os-upgrade==1.3.3
+# Note: The requirements.txt should contain pan-os-upgrade==1.3.4
+RUN pip install --no-cache-dir pan-os-upgrade==1.3.4
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
+## Version 1.3.4
+
+**Release Date:** *<20240303>*
+
+<!-- trunk-ignore(markdownlint/MD024) -->
+### What's New
+
+- Resolved an issue where snapshots would not be taken after an upgrade if settings.yaml file was present in the current working directory.
+
 ## Version 1.3.3
 
 **Release Date:** *<20240228>*

--- a/pan_os_upgrade/components/upgrade.py
+++ b/pan_os_upgrade/components/upgrade.py
@@ -726,57 +726,52 @@ def upgrade_firewall(
                 # Early return, no snapshot performed
                 return None
 
-        else:
-            # Perform the post-upgrade snapshot
-            post_snapshot = perform_snapshot(
-                actions=selected_actions,
-                file_path=f'assurance/snapshots/{hostname}/post/{time.strftime("%Y-%m-%d_%H-%M-%S")}.json',
-                firewall=firewall,
-                hostname=hostname,
-                settings_file_path=settings_file_path,
-            )
+        # Perform the post-upgrade snapshot
+        post_snapshot = perform_snapshot(
+            actions=selected_actions,
+            file_path=f'assurance/snapshots/{hostname}/post/{time.strftime("%Y-%m-%d_%H-%M-%S")}.json',
+            firewall=firewall,
+            hostname=hostname,
+            settings_file_path=settings_file_path,
+        )
 
-            # initialize object storing both snapshots
-            snapshot_compare = SnapshotCompare(
-                left_snapshot=pre_snapshot.model_dump(),
-                right_snapshot=post_snapshot.model_dump(),
-            )
+        # initialize object storing both snapshots
+        snapshot_compare = SnapshotCompare(
+            left_snapshot=pre_snapshot.model_dump(),
+            right_snapshot=post_snapshot.model_dump(),
+        )
 
-            pre_post_diff = snapshot_compare.compare_snapshots(selected_actions)
+        pre_post_diff = snapshot_compare.compare_snapshots(selected_actions)
 
-            logging.debug(
-                f"{get_emoji(action='report')} {hostname}: Snapshot comparison before and after upgrade {pre_post_diff}"
-            )
+        logging.debug(
+            f"{get_emoji(action='report')} {hostname}: Snapshot comparison before and after upgrade {pre_post_diff}"
+        )
 
-            folder_path = f"assurance/snapshots/{hostname}/diff"
-            pdf_report = (
-                f'{folder_path}/{time.strftime("%Y-%m-%d_%H-%M-%S")}_report.pdf'
-            )
-            ensure_directory_exists(file_path=pdf_report)
+        folder_path = f"assurance/snapshots/{hostname}/diff"
+        pdf_report = f'{folder_path}/{time.strftime("%Y-%m-%d_%H-%M-%S")}_report.pdf'
+        ensure_directory_exists(file_path=pdf_report)
 
-            # Generate the PDF report for the diff
-            generate_diff_report_pdf(
-                file_path=pdf_report,
-                hostname=hostname,
-                pre_post_diff=pre_post_diff,
-                target_version=target_version,
-            )
+        # Generate the PDF report for the diff
+        generate_diff_report_pdf(
+            file_path=pdf_report,
+            hostname=hostname,
+            pre_post_diff=pre_post_diff,
+            target_version=target_version,
+        )
 
-            logging.info(
-                f"{get_emoji(action='save')} {hostname}: Snapshot comparison PDF report saved to {pdf_report}"
-            )
+        logging.info(
+            f"{get_emoji(action='save')} {hostname}: Snapshot comparison PDF report saved to {pdf_report}"
+        )
 
-            json_report = (
-                f'{folder_path}/{time.strftime("%Y-%m-%d_%H-%M-%S")}_report.json'
-            )
+        json_report = f'{folder_path}/{time.strftime("%Y-%m-%d_%H-%M-%S")}_report.json'
 
-            # Write the file to the local filesystem as JSON
-            with open(json_report, "w") as file:
-                file.write(json.dumps(pre_post_diff))
+        # Write the file to the local filesystem as JSON
+        with open(json_report, "w") as file:
+            file.write(json.dumps(pre_post_diff))
 
-            logging.debug(
-                f"{get_emoji(action='save')} {hostname}: Snapshot comparison JSON report saved to {json_report}"
-            )
+        logging.debug(
+            f"{get_emoji(action='save')} {hostname}: Snapshot comparison JSON report saved to {json_report}"
+        )
 
     else:
         logging.error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.3.3"
+version = "1.3.4"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"


### PR DESCRIPTION
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Removes the `else` conditional in the post-upgrade snapshot workflow, which would have prevented snapshots from being taken on firewalls after they upgraded if a settings.yaml file was found in the current working directory.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!
