### PR TITLE
109 implement safeguards to prevent upgrades that may cause ha pair incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ logs
 .dev.env
 pan-os-upgrade.code-workspace
 pan_os_upgrade/*.yaml
+pan_os_upgrade/components/example.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,8 @@ WORKDIR /app
 COPY settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.3.5
-RUN pip install --no-cache-dir pan-os-upgrade==1.3.4
+# Note: The requirements.txt should contain pan-os-upgrade==1.3.6
+RUN pip install --no-cache-dir pan-os-upgrade==1.3.6
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,14 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
+## Version 1.3.6
+
+**Release Date:** *<20240317>*
+
+### What's New in version 1.3.7
+
+- Added compatibility check for devices that are in HA to ensure that two minor or major releases aren't being skipped, which will result in a `suspended` state on the firewall that's upgraded first, and then resulting in a broken HA after the second firewall completes its upgrade.
+
 ## Version 1.3.5
 
 **Release Date:** *<20240315>*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.3.5"
+version = "1.3.6"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"

--- a/tests/test_get_ha_status.py
+++ b/tests/test_get_ha_status.py
@@ -8,12 +8,15 @@ load_dotenv(".dev.env")
 
 # Updated test cases with corrected HA modes based on test results
 test_cases = [
-    ("panorama.cdot.io", "disabled", None),
     ("panorama1.cdot.io", "primary-active", None),
     ("panorama2.cdot.io", "secondary-passive", None),
-    ("lab-fw1.cdot.io", "disabled", None),
-    ("lab-fw6.cdot.io", "active", None),
-    ("lab-fw7.cdot.io", "passive", None),
+    # ("austin-fw1.cdot.io", "active-primary", None),
+    # ("austin-fw2.cdot.io", "active-secondary", None),
+    ("austin-fw3.cdot.io", "disabled", None),
+    ("dallas-fw1.cdot.io", "active", None),
+    ("dallas-fw2.cdot.io", "passive", None),
+    ("houston-fw1.cdot.io", "active", None),
+    ("houston-fw2.cdot.io", "passive", None),
 ]
 
 

--- a/tests/test_ha_sync_check_firewall.py
+++ b/tests/test_ha_sync_check_firewall.py
@@ -5,15 +5,15 @@ from pan_os_upgrade.components.ha import ha_sync_check_firewall
 # Define test cases for different HA synchronization states
 # 'expected_result' is True if HA sync check should pass, and False if it should fail or the device is not in HA
 test_cases = [
-    ("lab-fw1.cdot.io", None, True, False),  # Not in HA, should not pass
+    ("austin-fw3.cdot.io", None, True, False),  # Not in HA, should not pass
     (
-        "lab-fw6.cdot.io",
+        "dallas-fw1.cdot.io",
         {"result": {"group": {"running-sync": "synchronized"}}},
         True,
         True,
     ),  # In HA and synchronized
     (
-        "lab-fw7.cdot.io",
+        "dallas-fw2.cdot.io",
         {"result": {"group": {"running-sync": "unsynchronized"}}},
         True,
         False,

--- a/tests/test_ha_sync_check_panorama.py
+++ b/tests/test_ha_sync_check_panorama.py
@@ -5,7 +5,7 @@ from pan_os_upgrade.components.ha import ha_sync_check_panorama
 # Define test cases for different HA synchronization states for Panorama
 # 'expected_result' is True if HA sync check should pass, and False if it should fail or the device is not in HA
 test_cases = [
-    ("panorama.cdot.io", None, True, False),  # Not in HA, should not pass
+    # ("panorama.cdot.io", None, True, False),  # Not in HA, should not pass
     (
         "panorama1.cdot.io",
         {"result": {"running-sync": "synchronized"}},

--- a/tests/test_handle_firewall_ha.py
+++ b/tests/test_handle_firewall_ha.py
@@ -12,13 +12,13 @@ load_dotenv(".dev.env")
 
 # Define test cases with different HA configurations
 test_cases = [
-    ("lab-fw1.cdot.io", None),  # Standalone, expecting no HA peer and proceed
+    ("austin-fw3.cdot.io", None),  # Standalone, expecting no HA peer and proceed
     (
-        "lab-fw6.cdot.io",
+        "dallas-fw1.cdot.io",
         "active",
     ),  # HA and is active, might be added to revisit list, check proceed accordingly
     (
-        "lab-fw7.cdot.io",
+        "dallas-fw2.cdot.io",
         "passive",
     ),  # HA and is passive, expecting HA peer status and proceed
 ]

--- a/tests/test_handle_panorama_ha.py
+++ b/tests/test_handle_panorama_ha.py
@@ -12,11 +12,11 @@ load_dotenv(".dev.env")
 
 # Define test cases with different HA configurations
 test_cases = [
-    (
-        "panorama.cdot.io",
-        "standalone",
-        True,
-    ),  # Standalone Panorama, should proceed with upgrade
+    # (
+    #     "panorama.cdot.io",
+    #     "standalone",
+    #     True,
+    # ),  # Standalone Panorama, should proceed with upgrade
     (
         "panorama1.cdot.io",
         "primary-active",

--- a/tests/test_perform_readiness_checks.py
+++ b/tests/test_perform_readiness_checks.py
@@ -12,9 +12,9 @@ load_dotenv(".dev.env")
 
 # Define test cases for different firewalls
 test_cases = [
-    "lab-fw1.cdot.io",  # Standalone firewall
-    "lab-fw6.cdot.io",  # HA firewall 1
-    "lab-fw7.cdot.io",  # HA firewall 2
+    "austin-fw3.cdot.io",  # Standalone firewall
+    "dallas-fw1.cdot.io",  # HA firewall 1
+    "dallas-fw2.cdot.io",  # HA firewall 2
 ]
 
 


### PR DESCRIPTION
Here's a refined PR description based on the provided GitHub issue and changes:

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

This pull request introduces a safeguard feature in the pan-os-upgrade tool to prevent compatibility issues when upgrading PAN-OS firewalls in an HA pair. The feature gracefully exits the upgrade process if the user selects an upgrade version that is two or more minor releases ahead of the current version and the firewalls are in an HA state.

#### What does this pull request accomplish?

- Feature addition

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Changes made in this pull request

- Added a new function `check_ha_compatibility` to assess the compatibility of the target PAN-OS version with the current version in an HA pair.
- Updated the `software_update_check` function to call `check_ha_compatibility` when dealing with firewalls in an HA pair.
- If the target version is incompatible, a warning message is logged, and the function returns `False`, preventing the upgrade from proceeding.
- Updated docstrings for the `check_ha_compatibility` function to align with the project's documentation style.

#### Resolves issue

Resolves #109 

#### Motivation behind this feature

When upgrading PAN-OS firewalls in an HA pair, selecting a version that is two or more minor releases ahead of the current version can lead to compatibility issues. If one firewall is upgraded to a version that is significantly ahead of its peer, it may not be able to rejoin the HA pair after the upgrade, putting itself in a suspended state. When the upgrade process begins on the other firewall, it issues an HA state switch over. If the peer is in a suspended state, neither firewall will be able to forward traffic, as they both operate in a suspended state.

This safeguard feature mitigates this issue by gracefully exiting the upgrade process when the specified conditions are met. It helps prevent users from accidentally causing HA pair incompatibility issues and ensures they are aware of the potential consequences before proceeding with the upgrade.

#### Is there anything the reviewers should know?

Please review the changes carefully, especially the logic in the `check_ha_compatibility` function, to ensure it accurately identifies potential compatibility issues based on the version numbers and HA state.

