### PR TITLE
108 add support for activeactive ha upgrades in pan os upgrade

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,8 @@ WORKDIR /app
 COPY settings.yaml /app
 
 # Install any needed packages specified in requirements.txt
-# Note: The requirements.txt should contain pan-os-upgrade==1.3.6
-RUN pip install --no-cache-dir pan-os-upgrade==1.3.6
+# Note: The requirements.txt should contain pan-os-upgrade==1.3.7
+RUN pip install --no-cache-dir pan-os-upgrade==1.3.7
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,11 +2,21 @@
 
 Welcome to the release notes for the `pan-os-upgrade` tool. This document provides a detailed record of changes, enhancements, and fixes in each version of the tool.
 
-## Version 1.3.6
+## Version 1.3.7
 
 **Release Date:** *<20240317>*
 
 ### What's New in version 1.3.7
+
+- Added support for active/active firewall pairs.
+- Corrected an issue where parsing HA suspended state wasn't converting ElementTree object before conditional matching
+- Corrected an issue where suspending of peer HA was not being triggered in certain scenarios
+
+## Version 1.3.6
+
+**Release Date:** *<20240317>*
+
+### What's New in version 1.3.6
 
 - Added compatibility check for devices that are in HA to ensure that two minor or major releases aren't being skipped, which will result in a `suspended` state on the firewall that's upgraded first, and then resulting in a broken HA after the second firewall completes its upgrade.
 

--- a/pan_os_upgrade/components/assurance.py
+++ b/pan_os_upgrade/components/assurance.py
@@ -119,7 +119,7 @@ class AssuranceOptions:
             "enabled_by_default": True,
         },
         "free_disk_space": {
-            "description": "Check if a there is enough space on the `/opt/panrepo` volume for downloading an PanOS image.",
+            "description": "Check if a there is enough space on the `/opt/panrepo` volume for PAN-OS image.",
             "log_level": "warning",
             "exit_on_failure": False,
             "enabled_by_default": True,

--- a/pan_os_upgrade/components/utilities.py
+++ b/pan_os_upgrade/components/utilities.py
@@ -481,8 +481,8 @@ def create_firewall_mapping(
 
 
 def determine_upgrade(
+    current_version: str,
     hostname: str,
-    target_device: Union[Firewall, Panorama],
     target_maintenance: Union[int, str],
     target_major: int,
     target_minor: int,
@@ -498,9 +498,8 @@ def determine_upgrade(
 
     Parameters
     ----------
-    target_device : Union[Firewall, Panorama]
-        The device (Firewall or Panorama) to be evaluated for an upgrade. This must be an initialized instance with
-        connectivity to the device.
+    current_version : str
+        The device's current PAN-OS version to be evaluated for an upgrade.
     hostname : str
         The hostname or IP address of the target device. It is used for logging purposes to clearly identify the device
         in log messages.
@@ -540,7 +539,7 @@ def determine_upgrade(
     safeguard against unintended firmware changes that could affect device stability and security.
     """
 
-    current_version = parse_version(version=target_device.version)
+    current_version_parsed = parse_version(version=current_version)
 
     if isinstance(target_maintenance, int):
         # Handling integer maintenance version separately
@@ -552,15 +551,15 @@ def determine_upgrade(
         )
 
     logging.info(
-        f"{get_emoji(action='report')} {hostname}: Current version: {target_device.version}"
+        f"{get_emoji(action='report')} {hostname}: Current version: {current_version}"
     )
     logging.info(
         f"{get_emoji(action='report')} {hostname}: Target version: {target_major}.{target_minor}.{target_maintenance}"
     )
 
-    if current_version < target_version:
+    if current_version_parsed < target_version:
         logging.info(
-            f"{get_emoji(action='success')} {hostname}: Upgrade required from {target_device.version} to {target_major}.{target_minor}.{target_maintenance}"
+            f"{get_emoji(action='success')} {hostname}: Upgrade required from {current_version} to {target_major}.{target_minor}.{target_maintenance}"
         )
     else:
         logging.info(

--- a/pan_os_upgrade/main.py
+++ b/pan_os_upgrade/main.py
@@ -586,13 +586,13 @@ def batch(
     if confirmation:
         typer.echo(f"{get_emoji(action='start')} Proceeding with the upgrade...")
 
-        # Using ThreadPoolExecutor to manage threads
+        # Setting number of threads for concurrent upgrades
         threads = SETTINGS_FILE.get("concurrency.threads", 10)
         logging.info(
             f"{get_emoji(action='working')} {hostname}: Using {threads} threads."
         )
 
-        # Using ThreadPoolExecutor to manage threads for upgrading firewalls
+        # First round of upgrades, targeting all firewalls and placing active firewalls in an HA pair on a revisit list
         with ThreadPoolExecutor(max_workers=threads) as executor:
             # Store future objects along with firewalls for reference
             future_to_firewall = {
@@ -619,7 +619,7 @@ def batch(
                         f"{get_emoji(action='error')} {hostname}: Firewall {firewall.hostname} generated an exception: {exc}"
                     )
 
-        # Revisit the firewalls that were skipped in the initial pass
+        # Second round of upgrades, revisiting firewalls that were active in an HA pair and had the same version as their peers
         if target_devices_to_revisit:
             logging.info(
                 f"{get_emoji(action='start')} {hostname}: Revisiting firewalls that were active in an HA pair and had the same version as their peers."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-os-upgrade"
-version = "1.3.6"
+version = "1.3.7"
 description = "Python script to automate the upgrade process of PAN-OS firewalls."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 documentation = "https://cdot65.github.io/pan-os-upgrade/"

--- a/tests/test_determine_upgrade.py
+++ b/tests/test_determine_upgrade.py
@@ -39,11 +39,15 @@ def test_determine_upgrade():
     target_minor = 0  # For example, target PAN-OS x.0.x
     target_maintenance = "1-h1"  # For example, target PAN-OS x.x.1-h1
 
+    # Make sure we know about the system details - if we have connected via Panorama, this can be null without this.
+    target_device.refresh_system_info()
+    current_version = target_device.version
+
     # Use a try-except block to capture the SystemExit raised by the determine_upgrade function when no upgrade is needed or a downgrade is attempted
     try:
         determine_upgrade(
+            current_version=current_version,
             hostname=hostname,
-            target_device=target_device,
             target_maintenance=target_maintenance,
             target_major=target_major,
             target_minor=target_minor,

--- a/tests/test_get_ha_status.py
+++ b/tests/test_get_ha_status.py
@@ -10,8 +10,8 @@ load_dotenv(".dev.env")
 test_cases = [
     ("panorama1.cdot.io", "primary-active", None),
     ("panorama2.cdot.io", "secondary-passive", None),
-    # ("austin-fw1.cdot.io", "active-primary", None),
-    # ("austin-fw2.cdot.io", "active-secondary", None),
+    ("austin-fw1.cdot.io", "active-primary", None),
+    ("austin-fw2.cdot.io", "active-secondary", None),
     ("austin-fw3.cdot.io", "disabled", None),
     ("dallas-fw1.cdot.io", "active", None),
     ("dallas-fw2.cdot.io", "passive", None),

--- a/tests/test_handle_firewall_ha.py
+++ b/tests/test_handle_firewall_ha.py
@@ -18,7 +18,7 @@ test_cases = [
     ),  # HA and is active-primary, might be added to revisit list, check proceed accordingly
     (
         "austin-fw2.cdot.io",
-        "active",
+        "active-secondary",
     ),  # HA and is active, might be added to revisit list, check proceed accordingly
     ("austin-fw3.cdot.io", None),  # Standalone, expecting no HA peer and proceed
     (

--- a/tests/test_handle_firewall_ha.py
+++ b/tests/test_handle_firewall_ha.py
@@ -12,6 +12,14 @@ load_dotenv(".dev.env")
 
 # Define test cases with different HA configurations
 test_cases = [
+    (
+        "austin-fw1.cdot.io",
+        "active-primary",
+    ),  # HA and is active-primary, might be added to revisit list, check proceed accordingly
+    (
+        "austin-fw2.cdot.io",
+        "active",
+    ),  # HA and is active, might be added to revisit list, check proceed accordingly
     ("austin-fw3.cdot.io", None),  # Standalone, expecting no HA peer and proceed
     (
         "dallas-fw1.cdot.io",


### PR DESCRIPTION
Here's the updated GitHub pull request description for the feature enhancement:

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

This pull request introduces support for active/active HA upgrades to the pan-os-upgrade tool. The enhanced feature recognizes and handles different HA status types, including active-primary, active-secondary, and Tentative, and accounts for the HA3 interface unique to active/active HA configurations. It implements the proper active/active HA upgrade workflow, ensuring a smooth and automated upgrade process.

#### What does this pull request accomplish?

- Feature addition

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Changes made in this pull request

- Added `flatten_xml_to_dict` to imports from `pan_os_upgrade.components.utilities`.
- Modified the `handle_firewall_ha` function to:
  - Compare HA synchronization state instead of peer and local versions.
  - Handle active-primary and active-secondary states along with active and passive states.
  - Suspend the HA state of the passive or active-secondary device during the upgrade process.
  - Parse the XML response message using `flatten_xml_to_dict` to check the success of HA state suspension.
- Updated conditional statements to include active-primary and active-secondary states along with active and passive states.
- Moved the `check_ha_compatibility` before the suspension of the HA peer firewalls to prevent situations where a incompatible version was detected after the first firewall in a pair was suspended

#### Resolves issue

Resolves #108 

#### Motivation behind this feature

Currently, the pan-os-upgrade tool only supports HA upgrades for active/passive configurations. This limitation prevents users from efficiently upgrading their PAN-OS devices in active/active HA setups, requiring manual intervention and increasing the risk of errors.

The addition of active/active HA upgrade support greatly enhances the usability and versatility of the pan-os-upgrade tool. This feature benefits organizations running PAN-OS devices in active/active HA configurations, allowing them to automate their upgrade process and reduce the risk of human error. By encompassing both active/passive and active/active HA upgrades, pan-os-upgrade becomes a comprehensive solution for upgrading PAN-OS devices in various HA setups.

#### Is there anything the reviewers should know?

Please review the changes carefully, especially the modifications to the `handle_firewall_ha` function, to ensure proper handling of active/active HA configurations and the HA3 interface during the upgrade process. Thorough testing with various active/active HA setups is recommended to validate the functionality and compatibility of the new feature.
